### PR TITLE
Add localhost:3000 to proxy pass.

### DIFF
--- a/nameless_api.conf
+++ b/nameless_api.conf
@@ -4,7 +4,6 @@ server {
   listen 80;
   # Set the server name for this block to "nameless.api"
   server_name nameless.api;
-
   # Define a new location block for the root path ("/")
   location / {
     # Forward incoming requests to a server running on localhost:3000

--- a/nginx_install.sh
+++ b/nginx_install.sh
@@ -40,20 +40,32 @@ else
     sudo systemctl start nginx
 fi
 
-# Copy nginx configuration file to /etc/nginx/conf.d
-if [ -f /etc/nginx/conf.d/nginx.conf ]
+# Copy nameless_api.conf to /etc/nginx/sites-available directory.
+if [ -f /etc/nginx/sites-available/namelessapi ]
 then
-  echo -e "\n==== Nginx.conf present ====\n"
+    echo -e "\n==== Nameless_api.conf present in sites-available ====\n"
 else
-  echo -e "\n==== Copying nginx.conf ====\n"
-  sudo cp /home/jasondoze/nameless/nginx.conf /etc/nginx/conf.d/
+    echo -e "\n==== Copying nameless_api.conf to sites-available ====\n"
+    sudo cp /home/jasondoze/nameless/nameless_api.conf /etc/nginx/sites-available/namelessapi
 fi
 
-# Create a new configuration file for your application in the /etc/nginx/sites-available directory
-sudo cp /home/jasondoze/nameless/nginx.conf /etc/nginx/sites-available/namelessapi
+# Remove symlink to Nginx default in /etc/nginx/sites-enabled directory.
+if [ -L /etc/nginx/sites-enabled/default ]
+then
+    echo -e "\n==== Removing default symlink ====\n"
+    sudo rm /etc/nginx/sites-enabled/default
+else
+    echo -e "\n==== Default symlink not present ====\n"
+fi
 
-# Create a symbolic link to the configuration file in the /etc/nginx/sites-enabled directory
-sudo ln -s /etc/nginx/sites-available/namelessapi /etc/nginx/sites-enabled/
+# Create symlink in /etc/nginx/sites-enabled directory.
+if [ -L /etc/nginx/sites-enabled/namelessapi ]
+then
+    echo -e "\n==== Symlink present ====\n"
+else
+    echo -e "\n==== Creating symlink ====\n"
+    sudo ln -s /etc/nginx/sites-available/namelessapi /etc/nginx/sites-enabled/
+fi
 
 # Restart nginx service
 echo -e "\n==== Restarting nginx service ====\n"

--- a/service.sh
+++ b/service.sh
@@ -8,7 +8,7 @@ then
   echo -e "\n==== Service file present ====\n"
 else 
   echo -e "\n==== Copying api.service ====\n"
-  sudo cp /home/jasondoze/expressapi/api.service /lib/systemd/system/ && sudo systemctl daemon-reload
+  sudo cp /home/jasondoze/expressapi/api.service /etc/systemd/system/ && sudo systemctl daemon-reload
 fi
 
 # Restart express api.service


### PR DESCRIPTION
Add api.service to /etc/systemd/ not /lib/systemd in service.sh.

Add conditionals to copy and symlink nameless.api.conf to sites-available/enabled.

Rename nginx.conf to nameless_api.conf.

Remove symlink from nginx default.

Node app runs on the Pi's IP address at port 3000 and pi:3000 on local browser.

Signed-off-by: Jason Doze <dozejason@gmail.com>